### PR TITLE
Check for system is HMC managed and host is in standby or running

### DIFF
--- a/dump_dbus_util.cpp
+++ b/dump_dbus_util.cpp
@@ -2,15 +2,9 @@
 
 #include "dump_dbus_util.hpp"
 
-#include <fmt/format.h>
-
-#include <phosphor-logging/log.hpp>
 #include <variant>
-
 namespace openpower::dump
 {
-using ::phosphor::logging::level;
-using ::phosphor::logging::log;
 
 bool isDumpProgressCompleted(const DBusInteracesMap& intfMap)
 {
@@ -58,28 +52,21 @@ bool isDumpProgressCompleted(const DBusPropertiesMap& propMap)
 
 uint64_t getDumpSize(sdbusplus::bus::bus& bus, const std::string& objectPath)
 {
+    using ::openpower::dump::utility::DbusVariantType;
     uint64_t size = 0;
     try
     {
-        openpower::dump::utility::DbusVariantType value;
-        auto method = bus.new_method_call(dumpService, objectPath.c_str(),
-                                          dbusPropIntf, "Get");
-        method.append(entryIntf);
-        method.append("Size");
-        auto reply = bus.call(method);
-        reply.read(value);
-        const uint64_t* sizePtr = std::get_if<uint64_t>(&value);
-        if (sizePtr)
-        {
-            size = *sizePtr;
-        }
-        else
+        auto retVal = readDBusProperty<DbusVariantType>(
+            bus, dumpService, objectPath, entryIntf, "Size");
+        const uint64_t* sizePtr = std::get_if<uint64_t>(&retVal);
+        if (sizePtr == nullptr)
         {
             std::string err = fmt::format(
                 "Size value not set for dump object ({})", objectPath);
             log<level::ERR>(err.c_str());
             throw std::runtime_error(err);
         }
+        size = *sizePtr;
     }
     catch (const std::exception& ex)
     {
@@ -110,4 +97,103 @@ ManagedObjectType getDumpEntries(sdbusplus::bus::bus& bus)
     }
     return objects;
 }
+
+bool isSystemHMCManaged(sdbusplus::bus::bus& bus)
+{
+    using BiosBaseTableItem = std::pair<
+        std::string,
+        std::tuple<std::string, bool, std::string, std::string, std::string,
+                   std::variant<int64_t, std::string>,
+                   std::variant<int64_t, std::string>,
+                   std::vector<std::tuple<
+                       std::string, std::variant<int64_t, std::string>>>>>;
+    using BiosBaseTable = std::vector<BiosBaseTableItem>;
+    std::string hmcManaged{};
+    try
+    {
+        auto retVal = readDBusProperty<std::variant<BiosBaseTable>>(
+            bus, "xyz.openbmc_project.BIOSConfigManager",
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
+        const auto baseBiosTable = std::get_if<BiosBaseTable>(&retVal);
+        if (baseBiosTable == nullptr)
+        {
+            std::string err =
+                "Failed to read BIOSconfig property BaseBIOSTable";
+            log<level::ERR>(err.c_str());
+            throw std::runtime_error(err);
+        }
+        for (const auto& item : *baseBiosTable)
+        {
+            std::string attributeName = std::get<0>(item);
+            auto attrValue = std::get<5>(std::get<1>(item));
+            auto val = std::get_if<std::string>(&attrValue);
+            if (val != nullptr && attributeName == "pvm_hmc_managed")
+            {
+                hmcManaged = *val;
+                break;
+            }
+        }
+        if (hmcManaged.empty())
+        {
+            std::string err = "Failed to read pvm_hmc_managed property value";
+            log<level::ERR>(err.c_str());
+            return false;
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to read pvm_hmc_managed property ({})",
+                        ex.what())
+                .c_str());
+        return false;
+    }
+
+    if (hmcManaged == "Enabled")
+    {
+        return true;
+    }
+    return false;
+}
+
+bool isHostRunning(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        constexpr auto hostStateObjPath = "/xyz/openbmc_project/state/host0";
+        auto retVal = readDBusProperty<DBusProgressValue_t>(
+            bus, "xyz.openbmc_project.State.Host", hostStateObjPath,
+            "xyz.openbmc_project.State.Boot.Progress", "BootProgress");
+        const std::string* progPtr = std::get_if<std::string>(&retVal);
+        if (progPtr == nullptr)
+        {
+            std::string err = fmt::format(
+                "BootProgress value not set for host state object ({})",
+                hostStateObjPath);
+            log<level::ERR>(err.c_str());
+            return false;
+        }
+
+        log<level::ERR>(
+            fmt::format("DEVENDER BootProgress value set is ({})", *progPtr)
+                .c_str());
+        ProgressStages bootProgess = sdbusplus::xyz::openbmc_project::State::
+            Boot::server::Progress::convertProgressStagesFromString(*progPtr);
+        if ((bootProgess == ProgressStages::SystemInitComplete) ||
+            (bootProgess == ProgressStages::OSStart) ||
+            (bootProgess == ProgressStages::OSRunning))
+        {
+            return true;
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to read BootProgress property ({})", ex.what())
+                .c_str());
+    }
+    return false;
+}
+
 } // namespace openpower::dump

--- a/dump_dbus_util.hpp
+++ b/dump_dbus_util.hpp
@@ -2,13 +2,26 @@
 
 #include "dump_utility.hpp"
 
+#include <fmt/format.h>
+
 #include <cstdint>
+#include <phosphor-logging/log.hpp>
+#include <xyz/openbmc_project/State/Boot/Progress/server.hpp>
 
 namespace openpower::dump
 {
 using ::openpower::dump::utility::DBusInteracesMap;
 using ::openpower::dump::utility::DBusPropertiesMap;
 using ::openpower::dump::utility::ManagedObjectType;
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+
+using ProgressStages = sdbusplus::xyz::openbmc_project::State::Boot::server::
+    Progress::ProgressStages;
+using DBusProgressValue_t =
+    std::variant<std::string, bool, std::vector<uint8_t>,
+                 std::vector<std::string>>;
+
 /**
  * @brief Read progress property from the interface map object
  * @param[in] intfMap map of interfaces and its properties
@@ -37,4 +50,59 @@ uint64_t getDumpSize(sdbusplus::bus::bus& bus, const std::string& objectPath);
  * @return D-Bus entries with properties
  */
 ManagedObjectType getDumpEntries(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Read D-Bus property to check if system is HMC managed
+ * @detail Read the property from BIOSConfig.Manager interface, if attribute
+ *         is not set it will be assumed system is non HMC managed system.
+ *         Assumption is that if it is HMC managed the attribute will be set.
+ * @param[in] bus D-Bus handle
+ * @return true if HMC managed else false
+ */
+bool isSystemHMCManaged(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Read property value from the specified object and interface
+ * @param[in] bus D-Bus handle
+ * @param[in] service service which has implemented the interface
+ * @param[in] object object having has implemented the interface
+ * @param[in] intf interface having the property
+ * @param[in] prop name of the property to read
+ * @return property value
+ */
+template <typename T>
+T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
+                   const std::string& object, const std::string& intf,
+                   const std::string& prop)
+{
+    T retVal{};
+    try
+    {
+        auto properties =
+            bus.new_method_call(service.c_str(), object.c_str(),
+                                "org.freedesktop.DBus.Properties", "Get");
+        properties.append(intf);
+        properties.append(prop);
+        auto result = bus.call(properties);
+        result.read(retVal);
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to get the property ({}) interface ({}) "
+                        "error ({}) ",
+                        prop.c_str(), intf.c_str(), ex.what())
+                .c_str());
+        throw;
+    }
+    return retVal;
+}
+
+/**
+ * @brief Read D-Bus property to check if host is in running state
+ * @detail Read the Boot.Progress property to determine if host is running.
+ * @param[in] bus D-Bus handle
+ * @return true if host is running else false
+ */
+bool isHostRunning(sdbusplus::bus::bus& bus);
 } // namespace openpower::dump

--- a/dump_entry_watch.hpp
+++ b/dump_entry_watch.hpp
@@ -12,15 +12,22 @@ namespace openpower::dump
 using ::openpower::dump::utility::DumpType;
 using ::openpower::dump::utility::ManagedObjectType;
 using ::sdbusplus::message::object_path;
-class DumpDBusWatch
+
+/**
+ * @class DumpEntryDBusWatch
+ * @brief Add watch on new dump entries created so as to offload
+ * @details Adds watch on the dump progress property for the newly created
+ *  dumps. Initiates offload when dump progress property is changed to complete
+ */
+class DumpEntryDBusWatch
 {
   public:
-    DumpDBusWatch() = delete;
-    DumpDBusWatch(const DumpDBusWatch&) = delete;
-    DumpDBusWatch& operator=(const DumpDBusWatch&) = delete;
-    DumpDBusWatch(DumpDBusWatch&&) = delete;
-    DumpDBusWatch& operator=(DumpDBusWatch&&) = delete;
-    virtual ~DumpDBusWatch() = default;
+    DumpEntryDBusWatch() = delete;
+    DumpEntryDBusWatch(const DumpEntryDBusWatch&) = delete;
+    DumpEntryDBusWatch& operator=(const DumpEntryDBusWatch&) = delete;
+    DumpEntryDBusWatch(DumpEntryDBusWatch&&) = delete;
+    DumpEntryDBusWatch& operator=(DumpEntryDBusWatch&&) = delete;
+    virtual ~DumpEntryDBusWatch() = default;
 
     /**
      * @brief Watch on new dump objects created and property change
@@ -28,8 +35,8 @@ class DumpDBusWatch
      * @param[in] entryIntf - dump entry interface (BMC/Host/SBE/Hardware)
      * @param[in] dumpType - dump type to watch
      */
-    DumpDBusWatch(sdbusplus::bus::bus& bus, const std::string& entryIntf,
-                  DumpType dumpType);
+    DumpEntryDBusWatch(sdbusplus::bus::bus& bus, const std::string& entryIntf,
+                       DumpType dumpType);
 
     /**
      * @brief Add all in progress dumps to property watch

--- a/dump_offload_handler.hpp
+++ b/dump_offload_handler.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "dump_dbus_watch.hpp"
+#include "dump_entry_watch.hpp"
 #include "dump_utility.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -55,6 +55,6 @@ class DumpOffloadHandler
     const DumpType _dumpType;
 
     /* @brief watch on interfaces added/removed and property */
-    openpower::dump::DumpDBusWatch _dumpWatch;
+    openpower::dump::DumpEntryDBusWatch _dumpWatch;
 };
 } // namespace openpower::dump

--- a/dump_offload_mgr.cpp
+++ b/dump_offload_mgr.cpp
@@ -8,37 +8,116 @@ namespace openpower::dump
 {
 DumpOffloadManager::DumpOffloadManager(sdbusplus::bus::bus& bus) : _bus(bus)
 {
+    // Changing a system from hmc-managed to non-hmc manged is a disruptive
+    // process (Power off the system, do some clean ups and IPL).
+    // Changing a system from non-hmc managed to hmc-manged can be done at
+    // runtime.
+    // Not creating offloader objects if system is HMC managed
+    if (isSystemHMCManaged(_bus))
+    {
+        log<level::INFO>("DumpOffloadManager HMC managed system");
+        return;
+    }
+
+    // Perform offload only if host is in running state, else add watch on
+    // BootProgress property and offload when it moves to running state.
+    //
+    // At present we do not have a system-d target which indicates host is
+    // in running target with which we could have added wait-for condition
+    // for this service to start.
+    if (isHostRunning(bus) == false)
+    {
+        log<level::ERR>("Host is not running do not offload dump, add watch"
+                        " on host state");
+        _hostStatePropWatch = std::make_unique<sdbusplus::bus::match_t>(
+            _bus,
+            sdbusplus::bus::match::rules::propertiesChanged(
+                "/xyz/openbmc_project/state/host0",
+                "xyz.openbmc_project.State.Host"),
+            [this](auto& msg) { this->propertiesChanged(msg); });
+    }
+    else
+    {
+        addOffloadHandlers();
+    }
+}
+
+void DumpOffloadManager::propertiesChanged(sdbusplus::message::message& msg)
+{
+    std::string intf;
+    DBusPropertiesMap propMap;
+    msg.read(intf, propMap);
+    log<level::DEBUG>(
+        fmt::format("propertiesChanged interface ({}) ", intf).c_str());
+    for (auto prop : propMap)
+    {
+        if (prop.first == "BootProgress")
+        {
+            auto progress = std::get_if<std::string>(&prop.second);
+            if (progress != nullptr)
+            {
+                ProgressStages bootProgress =
+                    sdbusplus::xyz::openbmc_project::State::Boot::server::
+                        Progress::convertProgressStagesFromString(*progress);
+                if ((bootProgress == ProgressStages::SystemInitComplete) ||
+                    (bootProgress == ProgressStages::OSStart) ||
+                    (bootProgress == ProgressStages::OSRunning))
+                {
+                    // we are checking for multiple values as part of
+                    // BootProgress dump watch so we might get multiple
+                    // notifications so adding check to create handlers
+                    // only once.
+                    if (_fOffloaded == false)
+                    {
+                        addOffloadHandlers();
+                        offload();
+                        _fOffloaded = true;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void DumpOffloadManager::addOffloadHandlers()
+{
     // add bmc dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> bmcDump =
-        std::make_unique<DumpOffloadHandler>(bus, bmcEntryIntf, DumpType::bmc);
+        std::make_unique<DumpOffloadHandler>(_bus, bmcEntryIntf, DumpType::bmc);
     _dumpOffloadList.push_back(std::move(bmcDump));
 
     // add host dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> hostbootDump =
-        std::make_unique<DumpOffloadHandler>(bus, hostbootEntryIntf,
+        std::make_unique<DumpOffloadHandler>(_bus, hostbootEntryIntf,
                                              DumpType::hostboot);
     _dumpOffloadList.push_back(std::move(hostbootDump));
 
     // add sbe dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> sbeDump =
-        std::make_unique<DumpOffloadHandler>(bus, sbeEntryIntf, DumpType::sbe);
+        std::make_unique<DumpOffloadHandler>(_bus, sbeEntryIntf, DumpType::sbe);
     _dumpOffloadList.push_back(std::move(sbeDump));
 
-    // add hardware dump offload handler to the list of dump types to offload
+    // add hardware dump offload handler to the list of dump types to
+    // offload
     std::unique_ptr<DumpOffloadHandler> hardwareDump =
-        std::make_unique<DumpOffloadHandler>(bus, hardwareEntryIntf,
+        std::make_unique<DumpOffloadHandler>(_bus, hardwareEntryIntf,
                                              DumpType::hardware);
     _dumpOffloadList.push_back(std::move(hardwareDump));
 }
 
 void DumpOffloadManager::offload()
 {
-    // we can query only on the dump service not on individual entry types,
-    // so we get dumps of all types
-    ManagedObjectType objects = openpower::dump::getDumpEntries(_bus);
-    for (auto& dump : _dumpOffloadList)
+    // system can change from hon-hmc to hmc managed system, do not offload
+    // if system changed to hmc managed system
+    if (!isSystemHMCManaged(_bus))
     {
-        dump->offload(objects);
+        // we can query only on the dump service not on individual entry types,
+        // so we get dumps of all types
+        ManagedObjectType objects = openpower::dump::getDumpEntries(_bus);
+        for (auto& dump : _dumpOffloadList)
+        {
+            dump->offload(objects);
+        }
     }
 }
 } // namespace openpower::dump

--- a/dump_offload_mgr.hpp
+++ b/dump_offload_mgr.hpp
@@ -36,10 +36,29 @@ class DumpOffloadManager
     void offload();
 
   private:
+    /**
+     * @brief helper method to add offload handlers
+     * @return void
+     */
+    void addOffloadHandlers();
+
+    /**
+     * @brief Callback method for property change on the host state object
+     * @param[in] msg response msg from D-Bus request
+     * @return void
+     */
+    void propertiesChanged(sdbusplus::message::message& msg);
+
     /** @brief D-Bus to connect to */
     sdbusplus::bus::bus& _bus;
 
+    /** @brief flag to ensure offload handlers are created only once */
+    bool _fOffloaded = false;
+
     /*@brief list of dump offload objects */
     std::vector<std::unique_ptr<DumpOffloadHandler>> _dumpOffloadList;
+
+    /*@brief watch for host state change */
+    std::unique_ptr<sdbusplus::bus::match_t> _hostStatePropWatch;
 };
 } // namespace openpower::dump

--- a/meson.build
+++ b/meson.build
@@ -59,7 +59,7 @@ executable(
     'dump_offload_handler.cpp',
     'dump_dbus_util.cpp',
     'pldm_utils.cpp',
-    'dump_dbus_watch.cpp',
+    'dump_entry_watch.cpp',
     'dump_dbus_util.cpp',
     'dump_send_pldm_cmd.cpp',
     'pldm_oem_cmds.cpp',


### PR DESCRIPTION
1)Do not start the offload handler if system is hmc managed system.
Changing system from HMC managed to Non hmc is disruptive process
and requires REIPL

2) Check for system is hmc managed before any offload as system
can changed from Non HMC managed system to HMC managed at runtime.

3) If host is not at standby/runtime do not create the offload
handlers rather add watch on host state property.

3) When the host state property changes to standby/runtime create the
offload handlers and initiate the offload.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I1c0dd9ae5f69719f9519d15cab122d85fa6bb3d3