### PR TITLE
Add service file and checks for HMC and host state for offloading

### DIFF
--- a/dist/meson.build
+++ b/dist/meson.build
@@ -1,3 +1,5 @@
+systemd_system_unit_dir = systemd_dep.get_variable(
+    pkgconfig:'systemdsystemunitdir')
 conf_data = configuration_data()
 conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
 configure_file(
@@ -5,4 +7,4 @@ configure_file(
   output: 'pvm_dump_offload.service',
   configuration: conf_data,
   install: true,
-  install_dir: systemd_dep.get_pkgconfig_variable('systemdsystemunitdir'))
+  install_dir: systemd_system_unit_dir)

--- a/dist/pvm_dump_offload.service.in
+++ b/dist/pvm_dump_offload.service.in
@@ -1,7 +1,11 @@
 [Unit]
-Description=Dump offload to virtual machine
+Description=PowerVM Handler
 Wants=phosphor-debug-collector.service
 After=phosphor-debug-collector.service
+After=xyz.openbmc_project.biosconfig_manager.service
+After=obmc-power-on@0.target
+Conflicts=obmc-host-stop@0.target
+Conflicts=obmc-host-timeout@0.target
 
 [Service]
 ExecStart=@bindir@/pvm_dump_offload
@@ -9,4 +13,4 @@ Restart=always
 SyslogIdentifier=pvm_dump_offload
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=obmc-host-startmin@0.target

--- a/dump_dbus_util.cpp
+++ b/dump_dbus_util.cpp
@@ -2,15 +2,9 @@
 
 #include "dump_dbus_util.hpp"
 
-#include <fmt/format.h>
-
-#include <phosphor-logging/log.hpp>
 #include <variant>
-
 namespace openpower::dump
 {
-using ::phosphor::logging::level;
-using ::phosphor::logging::log;
 
 bool isDumpProgressCompleted(const DBusInteracesMap& intfMap)
 {
@@ -58,28 +52,21 @@ bool isDumpProgressCompleted(const DBusPropertiesMap& propMap)
 
 uint64_t getDumpSize(sdbusplus::bus::bus& bus, const std::string& objectPath)
 {
+    using ::openpower::dump::utility::DbusVariantType;
     uint64_t size = 0;
     try
     {
-        openpower::dump::utility::DbusVariantType value;
-        auto method = bus.new_method_call(dumpService, objectPath.c_str(),
-                                          dbusPropIntf, "Get");
-        method.append(entryIntf);
-        method.append("Size");
-        auto reply = bus.call(method);
-        reply.read(value);
-        const uint64_t* sizePtr = std::get_if<uint64_t>(&value);
-        if (sizePtr)
-        {
-            size = *sizePtr;
-        }
-        else
+        auto retVal = readDBusProperty<DbusVariantType>(
+            bus, dumpService, objectPath, entryIntf, "Size");
+        const uint64_t* sizePtr = std::get_if<uint64_t>(&retVal);
+        if (sizePtr == nullptr)
         {
             std::string err = fmt::format(
                 "Size value not set for dump object ({})", objectPath);
             log<level::ERR>(err.c_str());
             throw std::runtime_error(err);
         }
+        size = *sizePtr;
     }
     catch (const std::exception& ex)
     {
@@ -110,4 +97,97 @@ ManagedObjectType getDumpEntries(sdbusplus::bus::bus& bus)
     }
     return objects;
 }
+
+bool isSystemHMCManaged(sdbusplus::bus::bus& bus)
+{
+    using BiosBaseTableItem = std::pair<
+        std::string,
+        std::tuple<std::string, bool, std::string, std::string, std::string,
+                   std::variant<int64_t, std::string>,
+                   std::variant<int64_t, std::string>,
+                   std::vector<std::tuple<
+                       std::string, std::variant<int64_t, std::string>>>>>;
+    using BiosBaseTable = std::vector<BiosBaseTableItem>;
+    try
+    {
+        std::string hmcManaged{};
+        auto retVal = readDBusProperty<std::variant<BiosBaseTable>>(
+            bus, "xyz.openbmc_project.BIOSConfigManager",
+            "/xyz/openbmc_project/bios_config/manager",
+            "xyz.openbmc_project.BIOSConfig.Manager", "BaseBIOSTable");
+        const auto baseBiosTable = std::get_if<BiosBaseTable>(&retVal);
+        if (baseBiosTable == nullptr)
+        {
+            log<level::ERR>("Failed to read BIOSconfig property BaseBIOSTable");
+            return false;
+        }
+        for (const auto& item : *baseBiosTable)
+        {
+            std::string attributeName = std::get<0>(item);
+            auto attrValue = std::get<5>(std::get<1>(item));
+            auto val = std::get_if<std::string>(&attrValue);
+            if (val != nullptr && attributeName == "pvm_hmc_managed")
+            {
+                hmcManaged = *val;
+                break;
+            }
+        }
+        if (hmcManaged.empty())
+        {
+            log<level::ERR>("Failed to read pvm_hmc_managed property value");
+            return false;
+        }
+        if (hmcManaged == "Enabled")
+        {
+            return true;
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to read pvm_hmc_managed property ({})",
+                        ex.what())
+                .c_str());
+        return false;
+    }
+
+    return false;
+}
+
+bool isHostRunning(sdbusplus::bus::bus& bus)
+{
+    try
+    {
+        constexpr auto hostStateObjPath = "/xyz/openbmc_project/state/host0";
+        auto retVal = readDBusProperty<DBusProgressValue_t>(
+            bus, "xyz.openbmc_project.State.Host", hostStateObjPath,
+            "xyz.openbmc_project.State.Boot.Progress", "BootProgress");
+        const std::string* progPtr = std::get_if<std::string>(&retVal);
+        if (progPtr == nullptr)
+        {
+            std::string err = fmt::format(
+                "BootProgress value not set for host state object ({})",
+                hostStateObjPath);
+            log<level::ERR>(err.c_str());
+            return false;
+        }
+
+        ProgressStages bootProgess = sdbusplus::xyz::openbmc_project::State::
+            Boot::server::Progress::convertProgressStagesFromString(*progPtr);
+        if ((bootProgess == ProgressStages::SystemInitComplete) ||
+            (bootProgess == ProgressStages::OSStart) ||
+            (bootProgess == ProgressStages::OSRunning))
+        {
+            return true;
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to read BootProgress property ({})", ex.what())
+                .c_str());
+    }
+    return false;
+}
+
 } // namespace openpower::dump

--- a/dump_dbus_util.hpp
+++ b/dump_dbus_util.hpp
@@ -2,13 +2,26 @@
 
 #include "dump_utility.hpp"
 
+#include <fmt/format.h>
+
 #include <cstdint>
+#include <phosphor-logging/log.hpp>
+#include <xyz/openbmc_project/State/Boot/Progress/server.hpp>
 
 namespace openpower::dump
 {
 using ::openpower::dump::utility::DBusInteracesMap;
 using ::openpower::dump::utility::DBusPropertiesMap;
 using ::openpower::dump::utility::ManagedObjectType;
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+
+using ProgressStages = sdbusplus::xyz::openbmc_project::State::Boot::server::
+    Progress::ProgressStages;
+using DBusProgressValue_t =
+    std::variant<std::string, bool, std::vector<uint8_t>,
+                 std::vector<std::string>>;
+
 /**
  * @brief Read progress property from the interface map object
  * @param[in] intfMap map of interfaces and its properties
@@ -37,4 +50,59 @@ uint64_t getDumpSize(sdbusplus::bus::bus& bus, const std::string& objectPath);
  * @return D-Bus entries with properties
  */
 ManagedObjectType getDumpEntries(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Read D-Bus property to check if system is HMC managed
+ * @detail Read the property from BIOSConfig.Manager interface, if attribute
+ *         is not set it will be assumed system is non HMC managed system.
+ *         Assumption is that if it is HMC managed the attribute will be set.
+ * @param[in] bus D-Bus handle
+ * @return true if HMC managed else false
+ */
+bool isSystemHMCManaged(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Read property value from the specified object and interface
+ * @param[in] bus D-Bus handle
+ * @param[in] service service which has implemented the interface
+ * @param[in] object object having has implemented the interface
+ * @param[in] intf interface having the property
+ * @param[in] prop name of the property to read
+ * @return property value
+ */
+template <typename T>
+T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
+                   const std::string& object, const std::string& intf,
+                   const std::string& prop)
+{
+    T retVal{};
+    try
+    {
+        auto properties =
+            bus.new_method_call(service.c_str(), object.c_str(),
+                                "org.freedesktop.DBus.Properties", "Get");
+        properties.append(intf);
+        properties.append(prop);
+        auto result = bus.call(properties);
+        result.read(retVal);
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Failed to get the property ({}) interface ({}) "
+                        "object path ({}) error ({}) ",
+                        prop.c_str(), intf.c_str(), object.c_str(), ex.what())
+                .c_str());
+        throw;
+    }
+    return retVal;
+}
+
+/**
+ * @brief Read D-Bus property to check if host is in running state
+ * @detail Read the Boot.Progress property to determine if host is running.
+ * @param[in] bus D-Bus handle
+ * @return true if host is running else false
+ */
+bool isHostRunning(sdbusplus::bus::bus& bus);
 } // namespace openpower::dump

--- a/dump_dbus_watch.hpp
+++ b/dump_dbus_watch.hpp
@@ -12,6 +12,13 @@ namespace openpower::dump
 using ::openpower::dump::utility::DumpType;
 using ::openpower::dump::utility::ManagedObjectType;
 using ::sdbusplus::message::object_path;
+
+/**
+ * @class DumpDBusWatch
+ * @brief Add watch on new dump entries created so as to offload
+ * @details Adds watch on the dump progress property for the newly created
+ *  dumps. Initiates offload when dump progress property is changed to complete
+ */
 class DumpDBusWatch
 {
   public:

--- a/dump_offload_main.cpp
+++ b/dump_offload_main.cpp
@@ -1,3 +1,4 @@
+#include "dump_dbus_util.hpp"
 #include "dump_offload_mgr.hpp"
 
 #include <fmt/format.h>
@@ -15,8 +16,16 @@ int main()
     {
         auto bus = sdbusplus::bus::new_default();
         auto event = sdeventplus::Event::get_default();
-        openpower::dump::DumpOffloadManager manager(bus);
-        manager.offload();
+        // Changing a system from hmc-managed to non-hmc manged is a disruptive
+        // process (Power off the system, do some clean ups and IPL).
+        // Changing a system from non-hmc managed to hmc-manged can be done at
+        // runtime.
+        // Not creating offloader objects if system is HMC managed
+        if (!openpower::dump::isSystemHMCManaged(bus))
+        {
+            openpower::dump::DumpOffloadManager manager(bus);
+            manager.offload();
+        }
         bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
         return event.loop();
     }

--- a/dump_offload_mgr.cpp
+++ b/dump_offload_mgr.cpp
@@ -10,35 +10,102 @@ DumpOffloadManager::DumpOffloadManager(sdbusplus::bus::bus& bus) : _bus(bus)
 {
     // add bmc dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> bmcDump =
-        std::make_unique<DumpOffloadHandler>(bus, bmcEntryIntf, DumpType::bmc);
-    _dumpOffloadList.push_back(std::move(bmcDump));
+        std::make_unique<DumpOffloadHandler>(_bus, bmcEntryIntf, DumpType::bmc);
+    _dumpOffloadHandlerList.push_back(std::move(bmcDump));
 
     // add host dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> hostbootDump =
-        std::make_unique<DumpOffloadHandler>(bus, hostbootEntryIntf,
+        std::make_unique<DumpOffloadHandler>(_bus, hostbootEntryIntf,
                                              DumpType::hostboot);
-    _dumpOffloadList.push_back(std::move(hostbootDump));
+    _dumpOffloadHandlerList.push_back(std::move(hostbootDump));
 
     // add sbe dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> sbeDump =
-        std::make_unique<DumpOffloadHandler>(bus, sbeEntryIntf, DumpType::sbe);
-    _dumpOffloadList.push_back(std::move(sbeDump));
+        std::make_unique<DumpOffloadHandler>(_bus, sbeEntryIntf, DumpType::sbe);
+    _dumpOffloadHandlerList.push_back(std::move(sbeDump));
 
-    // add hardware dump offload handler to the list of dump types to offload
+    // add hardware dump offload handler to the list of dump types to
+    // offload
     std::unique_ptr<DumpOffloadHandler> hardwareDump =
-        std::make_unique<DumpOffloadHandler>(bus, hardwareEntryIntf,
+        std::make_unique<DumpOffloadHandler>(_bus, hardwareEntryIntf,
                                              DumpType::hardware);
-    _dumpOffloadList.push_back(std::move(hardwareDump));
+    _dumpOffloadHandlerList.push_back(std::move(hardwareDump));
+
+    // Do not offload when host is not in running state so adding watch on
+    // Boot progress property.
+    //
+    // Host might go from running state to unspecified state and come back
+    // and is independent of this service, so when host comes backs to runtime
+    // any dumps that are ignored when host is offline should be offloaded.
+    //
+    _hostStatePropWatch = std::make_unique<sdbusplus::bus::match_t>(
+        _bus,
+        sdbusplus::bus::match::rules::propertiesChanged(
+            "/xyz/openbmc_project/state/host0",
+            "xyz.openbmc_project.State.Boot.Progress"),
+        [this](auto& msg) { this->propertiesChanged(msg); });
+}
+
+void DumpOffloadManager::propertiesChanged(sdbusplus::message::message& msg)
+{
+    std::string intf;
+    DBusPropertiesMap propMap;
+    msg.read(intf, propMap);
+    log<level::INFO>(
+        fmt::format("Host state propertiesChanged interface ({}) ", intf)
+            .c_str());
+    for (auto prop : propMap)
+    {
+        if (prop.first == "BootProgress")
+        {
+            auto progress = std::get_if<std::string>(&prop.second);
+            if (progress != nullptr)
+            {
+                ProgressStages bootProgress =
+                    sdbusplus::xyz::openbmc_project::State::Boot::server::
+                        Progress::convertProgressStagesFromString(*progress);
+                if ((bootProgress == ProgressStages::SystemInitComplete) ||
+                    (bootProgress == ProgressStages::OSStart) ||
+                    (bootProgress == ProgressStages::OSRunning))
+                {
+                    log<level::INFO>(
+                        fmt::format("Offloading dumps host is now in  ({})"
+                                    " state ",
+                                    *progress)
+                            .c_str());
+                    offloadHelper();
+                }
+            }
+        }
+    }
+}
+
+void DumpOffloadManager::offloadHelper()
+{
+    // HMC might go from Non-hmc to HMC managed system so off load only
+    // if it is non HMC
+    if (!isSystemHMCManaged(_bus))
+    {
+        // we can query only on the dump service not on individual entry types,
+        // so we get dumps of all types
+        ManagedObjectType objects = openpower::dump::getDumpEntries(_bus);
+
+        // offload only if there are any non offloaded dumps
+        if (objects.size() > 0)
+        {
+            for (auto& dump : _dumpOffloadHandlerList)
+            {
+                dump->offload(objects);
+            }
+        }
+    }
 }
 
 void DumpOffloadManager::offload()
 {
-    // we can query only on the dump service not on individual entry types,
-    // so we get dumps of all types
-    ManagedObjectType objects = openpower::dump::getDumpEntries(_bus);
-    for (auto& dump : _dumpOffloadList)
+    if (isHostRunning(_bus))
     {
-        dump->offload(objects);
+        offloadHelper();
     }
 }
 } // namespace openpower::dump

--- a/dump_offload_mgr.hpp
+++ b/dump_offload_mgr.hpp
@@ -36,10 +36,26 @@ class DumpOffloadManager
     void offload();
 
   private:
+    /**
+     * @brief helper method to do the offload
+     * @return void
+     */
+    void offloadHelper();
+
+    /**
+     * @brief Callback method for property change on the host state object
+     * @param[in] msg response msg from D-Bus request
+     * @return void
+     */
+    void propertiesChanged(sdbusplus::message::message& msg);
+
     /** @brief D-Bus to connect to */
     sdbusplus::bus::bus& _bus;
 
     /*@brief list of dump offload objects */
-    std::vector<std::unique_ptr<DumpOffloadHandler>> _dumpOffloadList;
+    std::vector<std::unique_ptr<DumpOffloadHandler>> _dumpOffloadHandlerList;
+
+    /*@brief watch for host state change */
+    std::unique_ptr<sdbusplus::bus::match_t> _hostStatePropWatch;
 };
 } // namespace openpower::dump

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,8 @@ dump_offload_deps = [
     pldm_dep,
 ]
 
+subdir('dist')
+
 executable(
     'pvm_dump_offload',
     'dump_offload_main.cpp',


### PR DESCRIPTION
1)Do not start the the offload manager if system is hmc managed.

2)Changing system from HMC managed to Non hmc is disruptive process
and requires REIPL

3) Check for system is hmc managed before any offload as system
can be changed from Non HMC HMC managed system at runtime.

4) If host is not in running state do not offload the existing dumps
and rather add a watch on host state property.

5) If host is in running state intiate offload of existing dumps

3) When the host state property changes to running state create the
offload handlers and initiate the offload.

Tested: offlaoding after host goes to running state
pvm_dump_offload[14222]: Host is not running do not offload dump, add watch on host state
pvm_dump_offload[17032]: Host state propertiesChanged interface (xyz.openbmc_project.State.Boot.Progress)
pvm_dump_offload[17032]: Offloading dumps host is now in
(xyz.openbmc_project.State.Boot.Progress.ProgressStages.SystemInitComplete) state
pvm_dump_offload[17032]: DumpOffloadManager::offload
pvm_dump_offload[17032]: DumpOffloadHandler::offload entryType (xyz.openbmc_project.Dump.Entry.BMC) dumpType (0)
pvm_dump_offload[17032]: DumpOffloadHandler::offload dump object (/xyz/openbmc_project/dump/bmc/entry/5)

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I24f12d49c9438197b6470b910119c9786d6882ac