### PR TITLE
Add fmt library dependency to the meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,6 +37,7 @@ phosphor_logging_dep = dependency(
 
 systemd_dep = dependency('systemd')
 pldm_dep = dependency('libpldm')
+fmt_dep = dependency('fmt')
 
 configure_file(
     input: 'config.h.in',
@@ -50,6 +51,7 @@ dump_offload_deps = [
     sdbusplus_dep,
     sdeventplus_dep,
     pldm_dep,
+    fmt_dep
 ]
 
 subdir('dist')

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/fmtlib/fmt
+revision = HEAD


### PR DESCRIPTION
Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I9114c85a6e697b7edfdfb20dda1cd58feb4a7fa3