### PR TITLE
Fix application crash during deleting dumps

### DIFF
--- a/dump_dbus_watch.cpp
+++ b/dump_dbus_watch.cpp
@@ -11,6 +11,7 @@
 
 namespace openpower::dump
 {
+using ::openpower::dump::utility::DBusInteracesList;
 using ::openpower::dump::utility::DBusInteracesMap;
 using ::openpower::dump::utility::DBusPropertiesMap;
 using ::openpower::dump::utility::ManagedObjectType;
@@ -35,121 +36,163 @@ DumpDBusWatch::DumpDBusWatch(sdbusplus::bus::bus& bus,
 
 void DumpDBusWatch::interfaceAdded(sdbusplus::message::message& msg)
 {
-    // system can change from non-hmc to hmc managed system, do not offload
-    // if system changed to hmc managed system
-    if (isSystemHMCManaged(_bus))
+    try
     {
-        return;
+        // system can change from non-hmc to hmc managed system, do not offload
+        // if system changed to hmc managed system
+        if (isSystemHMCManaged(_bus))
+        {
+            return;
+        }
+        // Do not offload if host is not running
+        if (!isHostRunning(_bus))
+        {
+            return;
+        }
+        sdbusplus::message::object_path objPath;
+        DBusInteracesMap interfaces;
+        msg.read(objPath, interfaces);
+        auto iter = interfaces.find(_entryIntf);
+        if (iter == interfaces.end())
+        {
+            // ignore not specific to the dump type being watched
+            return;
+        }
+        log<level::INFO>(
+            fmt::format("interfaceAdded path ({})", objPath.str).c_str());
+        uint32_t id = std::stoul(objPath.filename());
+        _entryPropWatchList.emplace(
+            objPath, std::make_unique<sdbusplus::bus::match_t>(
+                         _bus,
+                         sdbusplus::bus::match::rules::propertiesChanged(
+                             objPath, progressIntf),
+                         [this, objPath, id](auto& msg) {
+                             this->propertiesChanged(objPath, id, msg);
+                         }));
     }
-    // Do not offload if host is not running
-    if (!isHostRunning(_bus))
+    catch (const std::exception& ex)
     {
-        return;
+        log<level::ERR>(
+            fmt::format("Exception in watch interfaceAdded ({})", ex.what())
+                .c_str());
+        throw;
     }
-    sdbusplus::message::object_path objPath;
-    DBusInteracesMap interfaces;
-    msg.read(objPath, interfaces);
-    auto iter = interfaces.find(_entryIntf);
-    if (iter == interfaces.end())
-    {
-        // ignore not specific to the dump type being watched
-        return;
-    }
-    log<level::INFO>(
-        fmt::format("interfaceAdded path ({})", objPath.str).c_str());
-    uint32_t id = std::stoul(objPath.filename());
-    _entryPropWatchList.emplace(
-        objPath, std::make_unique<sdbusplus::bus::match_t>(
-                     _bus,
-                     sdbusplus::bus::match::rules::propertiesChanged(
-                         objPath, progressIntf),
-                     [this, objPath, id](auto& msg) {
-                         this->propertiesChanged(objPath, id, msg);
-                     }));
 }
 
 void DumpDBusWatch::interfaceRemoved(sdbusplus::message::message& msg)
 {
-    sdbusplus::message::object_path objPath;
-    DBusInteracesMap interfaces;
-    msg.read(objPath, interfaces);
-    auto iter = interfaces.find(_entryIntf);
-    if (iter == interfaces.end())
+    try
     {
-        // ignore not specific to the dump type being watched
-        return;
+        sdbusplus::message::object_path objPath;
+        DBusInteracesList interfaces;
+        msg.read(objPath, interfaces);
+        auto iter = std::find(interfaces.begin(), interfaces.end(), _entryIntf);
+        if (iter == interfaces.end())
+        {
+            // ignore not specific to the dump type being watched
+            return;
+        }
+        log<level::INFO>(
+            fmt::format("interfaceRemoved path ({})", objPath.str).c_str());
+        _entryPropWatchList.erase(objPath);
     }
-    log<level::INFO>(
-        fmt::format("interfaceRemoved path ({})", objPath.str).c_str());
-    _entryPropWatchList.erase(objPath);
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Exception in watch interfaceRemoved ({})", ex.what())
+                .c_str());
+        throw;
+    }
 }
 
 void DumpDBusWatch::propertiesChanged(const object_path& objPath, uint32_t id,
                                       sdbusplus::message::message& msg)
 {
-    // system can change from non-hmc to hmc managed system, do not offload
-    // if system changed to hmc managed system
-    if (isSystemHMCManaged(_bus))
+    try
     {
-        return;
-    }
-    // Do not offload if host is not running
-    if (!isHostRunning(_bus))
-    {
-        return;
-    }
-    std::string interface;
-    DBusPropertiesMap propMap;
-    msg.read(interface, propMap);
-    log<level::INFO>(fmt::format("propertiesChanged object path ({}) id ({})",
-                                 objPath.str, id)
-                         .c_str());
-
-    bool fcomplete = isDumpProgressCompleted(propMap);
-    if (!fcomplete)
-    {
-        log<level::DEBUG>(
-            fmt::format("propertiesChanged object path ({}) status is not "
-                        "complete",
-                        objPath.str)
+        // system can change from non-hmc to hmc managed system, do not offload
+        // if system changed to hmc managed system
+        if (isSystemHMCManaged(_bus))
+        {
+            return;
+        }
+        // Do not offload if host is not running
+        if (!isHostRunning(_bus))
+        {
+            return;
+        }
+        std::string interface;
+        DBusPropertiesMap propMap;
+        msg.read(interface, propMap);
+        log<level::INFO>(
+            fmt::format("propertiesChanged object path ({}) id ({})",
+                        objPath.str, id)
                 .c_str());
-        return;
+
+        bool fcomplete = isDumpProgressCompleted(propMap);
+        if (!fcomplete)
+        {
+            log<level::DEBUG>(
+                fmt::format("propertiesChanged object path ({}) status is not "
+                            "complete",
+                            objPath.str)
+                    .c_str());
+            return;
+        }
+
+        uint64_t size = getDumpSize(_bus, objPath.str);
+        openpower::dump::pldm::sendNewDumpCmd(id, _dumpType, size);
+
+        _entryPropWatchList.erase(objPath);
     }
-
-    uint64_t size = getDumpSize(_bus, objPath.str);
-    openpower::dump::pldm::sendNewDumpCmd(id, _dumpType, size);
-
-    _entryPropWatchList.erase(objPath);
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Exception in watch propertiesChanged ({})", ex.what())
+                .c_str());
+        throw;
+    }
 }
 
 void DumpDBusWatch::addInProgressDumpsToWatch(const ManagedObjectType& objects)
 {
-    for (auto& object : objects)
+    try
     {
-        object_path objectPath = object.first;
-        auto iter = object.second.find(_entryIntf);
-        if (iter == object.second.end())
+        for (auto& object : objects)
         {
-            continue;
+            object_path objectPath = object.first;
+            auto iter = object.second.find(_entryIntf);
+            if (iter == object.second.end())
+            {
+                continue;
+            }
+            bool fcomplete = isDumpProgressCompleted(object.second);
+            if (!fcomplete)
+            {
+                uint32_t id = std::stoul(object.first.filename());
+                log<level::INFO>(
+                    fmt::format("addInProgressDumpsToWatch object path ({})",
+                                objectPath.str)
+                        .c_str());
+                _entryPropWatchList.emplace(
+                    objectPath,
+                    std::make_unique<sdbusplus::bus::match_t>(
+                        _bus,
+                        sdbusplus::bus::match::rules::propertiesChanged(
+                            objectPath, progressIntf),
+                        [this, objectPath, id](auto& msg) {
+                            this->propertiesChanged(objectPath, id, msg);
+                        }));
+            }
         }
-        bool fcomplete = isDumpProgressCompleted(object.second);
-        if (!fcomplete)
-        {
-            uint32_t id = std::stoul(object.first.filename());
-            log<level::INFO>(
-                fmt::format("addInProgressDumpsToWatch object path ({})",
-                            objectPath.str)
-                    .c_str());
-            _entryPropWatchList.emplace(
-                objectPath, std::make_unique<sdbusplus::bus::match_t>(
-                                _bus,
-                                sdbusplus::bus::match::rules::propertiesChanged(
-                                    objectPath, progressIntf),
-                                [this, objectPath, id](auto& msg) {
-                                    this->propertiesChanged(objectPath, id,
-                                                            msg);
-                                }));
-        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("Exception in addInProgressDumpsToWatch ({})",
+                        ex.what())
+                .c_str());
+        throw;
     }
 }
 

--- a/dump_offload_handler.cpp
+++ b/dump_offload_handler.cpp
@@ -28,11 +28,6 @@ void DumpOffloadHandler::offload(const ManagedObjectType& objects)
 {
     try
     {
-        log<level::INFO>(
-            fmt::format(
-                "DumpOffloadHandler::offload entryType ({}) dumpType ({})",
-                _entryIntf, _dumpType)
-                .c_str());
         ManagedObjectType inProgressDumps;
         for (auto& object : objects)
         {

--- a/dump_offload_mgr.cpp
+++ b/dump_offload_mgr.cpp
@@ -89,6 +89,10 @@ void DumpOffloadManager::offloadHelper()
         // we can query only on the dump service not on individual entry types,
         // so we get dumps of all types
         ManagedObjectType objects = openpower::dump::getDumpEntries(_bus);
+        log<level::INFO>(
+            fmt::format("Initiating existing dumps offload size is ({}) ",
+                        objects.size())
+                .c_str());
 
         // offload only if there are any non offloaded dumps
         if (objects.size() > 0)

--- a/dump_utility.hpp
+++ b/dump_utility.hpp
@@ -21,6 +21,7 @@ using DbusVariantType = sdbusplus::utility::dedup_variant_t<
  >;
 
 // clang-format on
+using DBusInteracesList = std::vector<std::string>;
 using DBusPropertiesMap = std::map<std::string, DbusVariantType>;
 using DBusInteracesMap = std::map<std::string, DBusPropertiesMap>;
 using ManagedObjectType =


### PR DESCRIPTION
1) Noticed wrong data structure was used for reading the
    interfacesRemoved callback sdbusplus message
2) Earlier was using sd::map but expected is std::vector.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>

Change-Id: I737e9aa6ca71ddca30120df36c9e00660554eea5