### PR TITLE
Queue the dumps to be offloaded and offload one at a time

### DIFF
--- a/dump_dbus_watch.hpp
+++ b/dump_dbus_watch.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "dump_offload_queue.hpp"
 #include "dump_utility.hpp"
 
 #include <map>
@@ -31,12 +32,13 @@ class DumpDBusWatch
 
     /**
      * @brief Watch on new dump objects created and property change
-     * @param[in] bus - Bus to attach to.
+     * @param[in] bus - Bus to attach to
+     * @param[in] offloader - To queue and offload dump
      * @param[in] entryIntf - dump entry interface (BMC/Host/SBE/Hardware)
      * @param[in] dumpType - dump type to watch
      */
-    DumpDBusWatch(sdbusplus::bus::bus& bus, const std::string& entryIntf,
-                  DumpType dumpType);
+    DumpDBusWatch(sdbusplus::bus::bus& bus, DumpOffloadQueue& offloader,
+                  const std::string& entryIntf, DumpType dumpType);
 
     /**
      * @brief Add all in progress dumps to property watch
@@ -72,6 +74,9 @@ class DumpDBusWatch
 
     /** @brief D-Bus to connect to */
     sdbusplus::bus::bus& _bus;
+
+    /** @brief Queue to offload dump requests */
+    DumpOffloadQueue& _dumpOffloader;
 
     /** @brief entry interface to watch for */
     std::string _entryIntf;

--- a/dump_offload_handler.hpp
+++ b/dump_offload_handler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dump_dbus_watch.hpp"
+#include "dump_offload_queue.hpp"
 #include "dump_utility.hpp"
 
 #include <sdbusplus/bus.hpp>
@@ -32,11 +33,12 @@ class DumpOffloadHandler
     /**
      * @brief constructor
      * @param[in] bus - D-Bus handle
+     * @param[in] offloader - To queue and offload dump
      * @param[in] entryIntf - entry interface to watch
      * @param[in] dumpType - type of the dump to watch
      */
-    DumpOffloadHandler(sdbusplus::bus::bus& bus, const std::string& entryIntf,
-                       DumpType dumpType);
+    DumpOffloadHandler(sdbusplus::bus::bus& bus, DumpOffloadQueue& offloader,
+                       const std::string& entryIntf, DumpType dumpType);
 
     /**
      * @brief Offload dump by sending request to PLDM
@@ -47,6 +49,9 @@ class DumpOffloadHandler
   protected:
     /* @brief sdbusplus DBus bus connection. */
     sdbusplus::bus::bus& _bus;
+
+    /** @brief Queue to offload dump requests */
+    DumpOffloadQueue& _dumpOffloader;
 
     /* @brief entry interface this object supports */
     const std::string _entryIntf;

--- a/dump_offload_main.cpp
+++ b/dump_offload_main.cpp
@@ -26,6 +26,7 @@ int main()
             log<level::ERR>("HMC managed system exiting the application");
             return 0;
         }
+        log<level::ERR>("Non HMC managed system initiating dump offloads");
         openpower::dump::DumpOffloadManager manager(bus);
         manager.offload();
         bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);

--- a/dump_offload_mgr.cpp
+++ b/dump_offload_mgr.cpp
@@ -6,29 +6,32 @@
 
 namespace openpower::dump
 {
-DumpOffloadManager::DumpOffloadManager(sdbusplus::bus::bus& bus) : _bus(bus)
+DumpOffloadManager::DumpOffloadManager(sdbusplus::bus::bus& bus) :
+    _bus(bus), _dumpOffloader(bus)
 {
     // add bmc dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> bmcDump =
-        std::make_unique<DumpOffloadHandler>(_bus, bmcEntryIntf, DumpType::bmc);
+        std::make_unique<DumpOffloadHandler>(_bus, _dumpOffloader, bmcEntryIntf,
+                                             DumpType::bmc);
     _dumpOffloadHandlerList.push_back(std::move(bmcDump));
 
     // add host dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> hostbootDump =
-        std::make_unique<DumpOffloadHandler>(_bus, hostbootEntryIntf,
-                                             DumpType::hostboot);
+        std::make_unique<DumpOffloadHandler>(
+            _bus, _dumpOffloader, hostbootEntryIntf, DumpType::hostboot);
     _dumpOffloadHandlerList.push_back(std::move(hostbootDump));
 
     // add sbe dump offload handler to the list of dump types to offload
     std::unique_ptr<DumpOffloadHandler> sbeDump =
-        std::make_unique<DumpOffloadHandler>(_bus, sbeEntryIntf, DumpType::sbe);
+        std::make_unique<DumpOffloadHandler>(_bus, _dumpOffloader, sbeEntryIntf,
+                                             DumpType::sbe);
     _dumpOffloadHandlerList.push_back(std::move(sbeDump));
 
     // add hardware dump offload handler to the list of dump types to
     // offload
     std::unique_ptr<DumpOffloadHandler> hardwareDump =
-        std::make_unique<DumpOffloadHandler>(_bus, hardwareEntryIntf,
-                                             DumpType::hardware);
+        std::make_unique<DumpOffloadHandler>(
+            _bus, _dumpOffloader, hardwareEntryIntf, DumpType::hardware);
     _dumpOffloadHandlerList.push_back(std::move(hardwareDump));
 
     // Do not offload when host is not in running state so adding watch on

--- a/dump_offload_mgr.hpp
+++ b/dump_offload_mgr.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "dump_offload_handler.hpp"
+#include "dump_offload_queue.hpp"
 
 #include <memory>
 #include <sdbusplus/bus.hpp>
@@ -51,6 +52,9 @@ class DumpOffloadManager
 
     /** @brief D-Bus to connect to */
     sdbusplus::bus::bus& _bus;
+
+    /** @brief Queue to offload dump requests */
+    DumpOffloadQueue _dumpOffloader;
 
     /*@brief list of dump offload objects */
     std::vector<std::unique_ptr<DumpOffloadHandler>> _dumpOffloadHandlerList;

--- a/dump_offload_queue.cpp
+++ b/dump_offload_queue.cpp
@@ -1,0 +1,99 @@
+#include "config.h"
+
+#include "dump_offload_queue.hpp"
+
+#include "dump_dbus_util.hpp"
+#include "dump_send_pldm_cmd.hpp"
+
+#include <fmt/format.h>
+
+#include <phosphor-logging/log.hpp>
+
+namespace openpower::dump
+{
+using ::openpower::dump::utility::DBusInteracesList;
+using ::phosphor::logging::level;
+using ::phosphor::logging::log;
+using ::sdbusplus::bus::match::rules::sender;
+
+DumpOffloadQueue::DumpOffloadQueue(sdbusplus::bus::bus& bus) : _bus(bus)
+{
+    _intfRemWatch = std::make_unique<sdbusplus::bus::match_t>(
+        bus,
+        sdbusplus::bus::match::rules::interfacesRemoved() + sender(dumpService),
+        [this](auto& msg) { this->interfaceRemoved(msg); });
+}
+
+void DumpOffloadQueue::enqueueForOffloading(const object_path& path,
+                                            DumpType type)
+{
+    log<level::INFO>(
+        fmt::format("queueing for offload path ({}) ", path.str).c_str());
+    _offloadDumpList.emplace(path.str, type);
+    offload();
+}
+
+void DumpOffloadQueue::offload()
+{
+    try
+    {
+        if (_offloadObjPath.empty() && !_offloadDumpList.empty())
+        {
+            auto iter = _offloadDumpList.begin();
+            _offloadObjPath = iter->first;
+            object_path path = _offloadObjPath;
+            uint32_t id = std::stoul(path.filename());
+            uint64_t size = getDumpSize(_bus, _offloadObjPath);
+            DumpType type = iter->second;
+            log<level::INFO>(
+                fmt::format("offload queue initiating offload ({}) id ({}) "
+                            "type ({}) size ({})",
+                            _offloadObjPath, id, type, size)
+                    .c_str());
+            openpower::dump::pldm::sendNewDumpCmd(id, type, size);
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("exception caught to send pldm cmd ({})", ex.what())
+                .c_str());
+        throw;
+    }
+}
+
+void DumpOffloadQueue::interfaceRemoved(sdbusplus::message::message& msg)
+{
+    try
+    {
+        sdbusplus::message::object_path objPath;
+        DBusInteracesList interfaces;
+        msg.read(objPath, interfaces);
+
+        if (_offloadObjPath == objPath.str)
+        {
+            log<level::INFO>(
+                fmt::format("offload completed ({}) removing from queue",
+                            _offloadObjPath)
+                    .c_str());
+            _offloadDumpList.erase(objPath.str);
+            _offloadObjPath.clear();
+            offload(); // offload the next dump if any
+        }
+        else
+        {
+            // delete from the offload list if incase the dump get deleted
+            // while it is queued for offload
+            _offloadDumpList.erase(objPath.str);
+        }
+    }
+    catch (const std::exception& ex)
+    {
+        log<level::ERR>(
+            fmt::format("exception in offloadqueue interfaceRemoved ({})",
+                        ex.what())
+                .c_str());
+        throw;
+    }
+}
+} // namespace openpower::dump

--- a/dump_offload_queue.hpp
+++ b/dump_offload_queue.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "dump_utility.hpp"
+
+#include <map>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+namespace openpower::dump
+{
+using ::openpower::dump::utility::DumpType;
+using ::sdbusplus::message::object_path;
+
+/**
+ * @class DumpOffloadQueue
+ * @brief Queue to send dump offload requests when one offload is completed
+ * @details PHYP could not handle multiple dump offload requests at the same
+ *          time, queueing the requests and sending when one offload is done
+ */
+class DumpOffloadQueue
+{
+  public:
+    DumpOffloadQueue() = delete;
+    DumpOffloadQueue(const DumpOffloadQueue&) = delete;
+    DumpOffloadQueue& operator=(const DumpOffloadQueue&) = delete;
+    DumpOffloadQueue(DumpOffloadQueue&&) = delete;
+    DumpOffloadQueue& operator=(DumpOffloadQueue&&) = delete;
+    virtual ~DumpOffloadQueue() = default;
+
+    /**
+     * @brief Constructor
+     * @param[in] bus - D-Bus to attach to
+     */
+    DumpOffloadQueue(sdbusplus::bus::bus& bus);
+
+    /**
+     * @brief Queue the dumps for offloading
+     * @param[in] path - D-Bus path of the dump object
+     * @param[in] path - type of the dump to offload
+     */
+    void enqueueForOffloading(const object_path& path, DumpType type);
+
+  private:
+    /**
+     * @brief Offload the next available dump from the queue
+     */
+    void offload();
+
+    /**
+     * @brief Callback method for deletion of dump entry object
+     * @param[in] msg response msg from D-Bus request
+     * @return void
+     */
+    void interfaceRemoved(sdbusplus::message::message& msg);
+
+    /** @brief D-Bus to connect to */
+    sdbusplus::bus::bus& _bus;
+
+    /** @brief map of property change request for the corresponding entry */
+    std::map<std::string, DumpType> _offloadDumpList;
+
+    /** @brief dump object currently in offload */
+    std::string _offloadObjPath;
+
+    /** @brief watch pointer for interfaces removed */
+    std::unique_ptr<sdbusplus::bus::match_t> _intfRemWatch;
+};
+} // namespace openpower::dump

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ executable(
     'dump_dbus_util.cpp',
     'dump_send_pldm_cmd.cpp',
     'pldm_oem_cmds.cpp',
+    'dump_offload_queue.cpp',
     dependencies: dump_offload_deps,
     install: true,
 )


### PR DESCRIPTION
1)PHYP is not queueing the dumps to be offloaded so was
causing hostboot TI

2) Modified to queue the existing and newly added dumps.

3) When the dump is offloaded PHYP will notify to delete
the dump.

4) Add watch on delete dump entry , when notified remove
the entry from the queue and initiate offload of the next dump

Tested
1) Tested by manually deleting the dump for which request has
been sent to PHYP and ensured that it is removed from the queue
and the next dump offload request is sent.

pvm_dump_offload[8580]: DumpOffloadHandler::offload dump object (/xyz/openbmc_project/dump/bmc/entry/65)
pvm_dump_offload[8580]: offloadqueue queueing for offload path (/xyz/openbmc_project/dump/bmc/entry/65)
pvm_dump_offload[8580]: offloadqueue send PLDM command path (/xyz/openbmc_project/dump/bmc/entry/65) id (65) type (0) size (613932)
pvm_dump_offload[8580]: sendNewDumpCmd Id(65) Size(613932) Type(0) PldmDumpType(15)
pvm_dump_offload[8580]: Acknowledged PHYP about new dump, dumpId(65)

pvm_dump_offload[8580]: interfaceRemoved path (/xyz/openbmc_project/dump/bmc/entry/65)
pvm_dump_offload[8580]: offloadqueue interfaceRemoved (/xyz/openbmc_project/dump/bmc/entry/65)
pvm_dump_offload[8580]: offloadqueue send PLDM command path (/xyz/openbmc_project/dump/hostboot/entry/20000001) id (20000001) type (2) size
(1133053)
pvm_dump_offload[8580]: sendNewDumpCmd Id(20000001) Size(1133053) Type(2) PldmDumpType(17)
pvm_dump_offload[8580]: Acknowledged PHYP about new dump, dumpId(20000001)

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>

Change-Id: I0ced3736d9346582027abcae445145ad619049d2