### PR TITLE
optimization done for fetching the dumps and watching

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,7 +1,6 @@
 #pragma once
 
 constexpr auto bmcDumpObjPath = "/xyz/openbmc_project/dump/bmc";
-constexpr auto bmcEntryObjPath = "/xyz/openbmc_project/dump/bmc/entry";
 constexpr auto dumpService = "xyz.openbmc_project.Dump.Manager";
 constexpr auto dumpObjPath = "/xyz/openbmc_project/dump";
 constexpr auto dbusPropIntf = "org.freedesktop.DBus.Properties";
@@ -14,3 +13,7 @@ constexpr auto bmcEntryIntf = "xyz.openbmc_project.Dump.Entry.BMC";
 constexpr auto hostbootEntryIntf = "com.ibm.Dump.Entry.Hostboot";
 constexpr auto sbeEntryIntf = "com.ibm.Dump.Entry.SBE";
 constexpr auto hardwareEntryIntf = "com.ibm.Dump.Entry.Hardware";
+constexpr auto bmcEntryObjPath = "/xyz/openbmc_project/dump/bmc/entry/";
+constexpr auto hostbootEntryObjPath = "/xyz/openbmc_project/dump/hostboot/entry/";
+constexpr auto hardwareEntryObjPath = "/xyz/openbmc_project/dump/hardware/entry/";
+constexpr auto sbeEntryObjPath = "/xyz/openbmc_project/dump/sbe/entry/";

--- a/dist/pvm_dump_offload.service.in
+++ b/dist/pvm_dump_offload.service.in
@@ -9,7 +9,7 @@ Conflicts=obmc-host-timeout@0.target
 
 [Service]
 ExecStart=@bindir@/pvm_dump_offload
-Restart=always
+Restart=on-failure
 SyslogIdentifier=pvm_dump_offload
 
 [Install]

--- a/dump_dbus_util.hpp
+++ b/dump_dbus_util.hpp
@@ -10,11 +10,10 @@
 
 namespace openpower::dump
 {
-using ::openpower::dump::utility::DBusInteracesMap;
 using ::openpower::dump::utility::DBusPropertiesMap;
-using ::openpower::dump::utility::ManagedObjectType;
 using ::phosphor::logging::level;
 using ::phosphor::logging::log;
+using ::sdbusplus::message::object_path;
 
 using ProgressStages = sdbusplus::xyz::openbmc_project::State::Boot::server::
     Progress::ProgressStages;
@@ -24,18 +23,19 @@ using DBusProgressValue_t =
 
 /**
  * @brief Read progress property from the interface map object
- * @param[in] intfMap map of interfaces and its properties
- * @return true if progress is complete else false
- */
-bool isDumpProgressCompleted(const DBusInteracesMap& intfMap);
-
-/**
- * @brief Read progress property from the interface map object
- * @param[in] propMao map of properties and its values
+ * @param[in] propMap map of properties and its values
  * @return true if progress is complete else false
  */
 bool isDumpProgressCompleted(const DBusPropertiesMap& propMap);
 
+/**
+ * @brief Read progress property from the D-Bus object
+ * @param[in] bus - D-Bus handle
+ * @param[in] objectPath - D-Bus object path
+ * @return true if progress is complete else false
+ */
+bool isDumpProgressCompleted(sdbusplus::bus::bus& bus,
+                             const std::string& objectPath);
 /**
  * @brief Read dump size from the interface map object
  * @param[in] bus - D-Bus handle
@@ -43,13 +43,6 @@ bool isDumpProgressCompleted(const DBusPropertiesMap& propMap);
  * @return dump size value
  */
 uint64_t getDumpSize(sdbusplus::bus::bus& bus, const std::string& objectPath);
-
-/**
- * @brief Read available dump entries from the system
- * @param[in] bus D-Bus handle
- * @return D-Bus entries with properties
- */
-ManagedObjectType getDumpEntries(sdbusplus::bus::bus& bus);
 
 /**
  * @brief Read D-Bus property to check if system is HMC managed
@@ -105,4 +98,14 @@ T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
  * @return true if host is running else false
  */
 bool isHostRunning(sdbusplus::bus::bus& bus);
+
+/**
+ * @brief Read avaialble dumps implementing the dump type entry interface
+ * @param[in] bus D-Bus handle
+ * @param[in] entryIntf identifies type of the dump
+ * @return D-Bus object paths
+ */
+const std::vector<std::string>
+    getDumpEntryObjPaths(sdbusplus::bus::bus& bus,
+                         const std::string& entryIntf);
 } // namespace openpower::dump

--- a/dump_dbus_watch.hpp
+++ b/dump_dbus_watch.hpp
@@ -10,8 +10,8 @@
 
 namespace openpower::dump
 {
+
 using ::openpower::dump::utility::DumpType;
-using ::openpower::dump::utility::ManagedObjectType;
 using ::sdbusplus::message::object_path;
 
 /**
@@ -33,19 +33,21 @@ class DumpDBusWatch
     /**
      * @brief Watch on new dump objects created and property change
      * @param[in] bus - Bus to attach to
-     * @param[in] offloader - To queue and offload dump
+     * @param[in] dumpQueue - To queue and offload dump
      * @param[in] entryIntf - dump entry interface (BMC/Host/SBE/Hardware)
+     * @param[in] entryObjPath - dump entry object path
      * @param[in] dumpType - dump type to watch
      */
-    DumpDBusWatch(sdbusplus::bus::bus& bus, DumpOffloadQueue& offloader,
-                  const std::string& entryIntf, DumpType dumpType);
+    DumpDBusWatch(sdbusplus::bus::bus& bus, DumpOffloadQueue& dumpQueue,
+                  const std::string& entryIntf, const std::string& entryObjPath,
+                  DumpType dumpType);
 
     /**
      * @brief Add all in progress dumps to property watch
-     * @param[in] objects dump objects whose progress is not yet completed
+     * @param[in] objects dump object paths
      * @return void
      */
-    void addInProgressDumpsToWatch(const ManagedObjectType& objects);
+    void addInProgressDumpsToWatch(std::vector<std::string> paths);
 
   private:
     /**
@@ -65,18 +67,17 @@ class DumpDBusWatch
     /**
      * @brief Callback method for property change on the entry object
      * @param[in] objPath Object path of the dump entry
-     * @param[in] id ID of the dump entry
      * @param[in] msg response msg from D-Bus request
      * @return void
      */
-    void propertiesChanged(const object_path& objPath, uint32_t id,
+    void propertiesChanged(const object_path& objPath,
                            sdbusplus::message::message& msg);
 
     /** @brief D-Bus to connect to */
     sdbusplus::bus::bus& _bus;
 
     /** @brief Queue to offload dump requests */
-    DumpOffloadQueue& _dumpOffloader;
+    DumpOffloadQueue& _dumpQueue;
 
     /** @brief entry interface to watch for */
     std::string _entryIntf;

--- a/dump_offload_handler.hpp
+++ b/dump_offload_handler.hpp
@@ -9,8 +9,6 @@
 
 namespace openpower::dump
 {
-using ::openpower::dump::utility::DBusInteracesMap;
-using ::openpower::dump::utility::ManagedObjectType;
 
 /**
  * @class DumpOffloadHandler
@@ -35,16 +33,18 @@ class DumpOffloadHandler
      * @param[in] bus - D-Bus handle
      * @param[in] offloader - To queue and offload dump
      * @param[in] entryIntf - entry interface to watch
+     * @param[in] entryObjPath - entry object path to watch
      * @param[in] dumpType - type of the dump to watch
      */
     DumpOffloadHandler(sdbusplus::bus::bus& bus, DumpOffloadQueue& offloader,
-                       const std::string& entryIntf, DumpType dumpType);
+                       const std::string& entryIntf,
+                       const std::string& entryObjPath, DumpType dumpType);
 
     /**
      * @brief Offload dump by sending request to PLDM
      * @param[in] existing dump objects
      */
-    void offload(const ManagedObjectType& objects);
+    void offload();
 
   protected:
     /* @brief sdbusplus DBus bus connection. */

--- a/dump_offload_main.cpp
+++ b/dump_offload_main.cpp
@@ -21,12 +21,20 @@ int main()
         // Changing a system from non-hmc managed to hmc-manged can be done at
         // runtime.
         // Not creating offloader objects if system is HMC managed
+        // TODO #https://github.com/ibm-openbmc/powervm-handler/issues/8
         if (openpower::dump::isSystemHMCManaged(bus))
         {
             log<level::ERR>("HMC managed system exiting the application");
             return 0;
         }
-        log<level::ERR>("Non HMC managed system initiating dump offloads");
+        log<level::INFO>("Non HMC managed system initiating dump offloads");
+
+        if (!openpower::dump::isHostRunning(bus))
+        {
+            log<level::ERR>("Host is not in running state, offload will start "
+                            "when Host changes to running state");
+        }
+
         openpower::dump::DumpOffloadManager manager(bus);
         manager.offload();
         bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);

--- a/dump_offload_mgr.hpp
+++ b/dump_offload_mgr.hpp
@@ -38,23 +38,17 @@ class DumpOffloadManager
 
   private:
     /**
-     * @brief helper method to do the offload
-     * @return void
-     */
-    void offloadHelper();
-
-    /**
      * @brief Callback method for property change on the host state object
      * @param[in] msg response msg from D-Bus request
      * @return void
      */
-    void propertiesChanged(sdbusplus::message::message& msg);
+    void hostStatePropChanged(sdbusplus::message::message& msg);
 
     /** @brief D-Bus to connect to */
     sdbusplus::bus::bus& _bus;
 
     /** @brief Queue to offload dump requests */
-    DumpOffloadQueue _dumpOffloader;
+    DumpOffloadQueue _dumpQueue;
 
     /*@brief list of dump offload objects */
     std::vector<std::unique_ptr<DumpOffloadHandler>> _dumpOffloadHandlerList;

--- a/dump_send_pldm_cmd.cpp
+++ b/dump_send_pldm_cmd.cpp
@@ -15,7 +15,7 @@ using ::phosphor::logging::log;
 void sendNewDumpCmd(uint32_t dumpId, DumpType dumpType, uint64_t dumpSize)
 {
     uint32_t pldmDumpType = 0;
-    // TODO use PLDM dump types when the same is added to the header file
+    // TODO https://github.com/ibm-openbmc/powervm-handler/issues/9
     switch (dumpType)
     {
         case DumpType::bmc:


### PR DESCRIPTION
Earlier I could not find the correct D-Bus mechanism to query
the BMC/Hostboot/SBE/Hardware only dumps in there respective
handler and watchers, now found the same so restructured the code.

Also fixed some corner cases like deleting dumps while one in progress

Fixed restart the service only on failure

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>

Change-Id: Ibf4a81ee1970990dde06908ebcfcd48644a77fc1