### PR TITLE
Fix invalid size used for newfile available pldm command

### DIFF
--- a/dump/pldm_oem_cmds.hpp
+++ b/dump/pldm_oem_cmds.hpp
@@ -13,7 +13,7 @@ namespace internal
 mctp_eid_t readEID();
 } // namespace internal
 /**
- * @brief Acknowledge new dump creation
+ * @brief Send new file available PLDM command
  *
  * @param[in] id - Dump id
  * @param[in] dumpType - Type of the dump.
@@ -21,5 +21,6 @@ mctp_eid_t readEID();
  * @return NULL
  *
  */
-void ackNewDump(uint32_t id, pldm_fileio_file_type dumpType, uint64_t dumpSize);
+void newFileAvailable(uint32_t id, pldm_fileio_file_type dumpType,
+                      uint64_t dumpSize);
 } // namespace openpower::dump::pldm

--- a/dump/send_pldm_cmd.cpp
+++ b/dump/send_pldm_cmd.cpp
@@ -42,7 +42,7 @@ void sendNewDumpCmd(uint32_t dumpId, DumpType dumpType, uint64_t dumpSize)
                                  "PldmDumpType({})",
                                  dumpId, dumpSize, dumpType, pldmDumpType)
                          .c_str());
-    openpower::dump::pldm::ackNewDump(
+    openpower::dump::pldm::newFileAvailable(
         dumpId, static_cast<pldm_fileio_file_type>(pldmDumpType), dumpSize);
 }
 } // namespace openpower::dump::pldm


### PR DESCRIPTION
1)Using invalid size to compute the new file available
request sent to PLDM when new dump is available.

Tested:
pvm_dump_offload[3912]: sendNewDumpCmd Id(1) Size(7748335) Type(0)
PldmDumpType(15)
pvm_dump_offload[3912]: newFileAvailable encode_new_file_req Instance ID (0)
DumpID (1) DumpType (15) DumpSize(7748335)  ReqMsgSize(17)

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>

Change-Id: Icc0b528e9a6f6cf16f335d65de95f9500d766bc5