### PR TITLE
dump: consider hmc state change only if it differs with current state

### DIFF
--- a/dump/hmc_state_watch.cpp
+++ b/dump/hmc_state_watch.cpp
@@ -53,12 +53,10 @@ void HMCStateWatch::propertyChanged(sdbusplus::message::message& msg)
                     auto val = std::get_if<std::string>(&attrValue);
                     if (val != nullptr && *val == "Enabled")
                     {
-                        log<level::INFO>("System changed to HMC managed");
                         _dumpQueue.hmcStateChange(true);
                     }
                     else
                     {
-                        log<level::INFO>("System changed to non HMC managed");
                         _dumpQueue.hmcStateChange(false);
                     }
                     break;

--- a/dump/host_offloader_queue.cpp
+++ b/dump/host_offloader_queue.cpp
@@ -90,18 +90,23 @@ void HostOffloaderQueue::hostStateChange(bool isRunning)
     }
 }
 
-void HostOffloaderQueue::hmcStateChange(bool isHMCManagedSystem)
+void HostOffloaderQueue::hmcStateChange(bool hmcManaged)
 {
-    isHMCManagedSystem = isHMCManagedSystem;
-    if (!isHMCManagedSystem)
+    if (isHMCManagedSystem != hmcManaged)
     {
-        // dumps might have been queued while system is HMC managed, offload
-        // them
-        startTimer();
-    }
-    else
-    {
-        stopTimer();
+        isHMCManagedSystem = hmcManaged;
+        if (!isHMCManagedSystem)
+        {
+            // dumps might have been queued while system is HMC managed, offload
+            // them
+            log<level::INFO>("System changed to non HMC managed");
+            startTimer();
+        }
+        else
+        {
+            log<level::INFO>("System changed to HMC managed");
+            stopTimer();
+        }
     }
 }
 

--- a/dump/host_offloader_queue.hpp
+++ b/dump/host_offloader_queue.hpp
@@ -61,9 +61,9 @@ class HostOffloaderQueue
 
     /**
      * @brief HMC state change notification form HMC state watch
-     * @param[in] isHMCManagedSystem - True if system is HMC managed
+     * @param[in] hmcManaged - True if system is HMC managed
      */
-    void hmcStateChange(bool isHMCManagedSystem);
+    void hmcStateChange(bool hmcManaged);
 
   private:
     /**


### PR DESCRIPTION
Consider hmc state change only if the value differs with current value, as BaseBIOSTable is a big property set the hmcstate change watch might be notififed for any change in its property set.

Change-Id: I51ba8dac8780017ff786a10b0688b37969a807c8