### PR TITLE
dump : fix check for host state running

### DIFF
--- a/dump/dbus_util.cpp
+++ b/dump/dbus_util.cpp
@@ -154,7 +154,7 @@ bool isHostRunning(sdbusplus::bus::bus& bus)
             bus, "xyz.openbmc_project.State.Host", hostStateObjPath,
             "xyz.openbmc_project.State.Boot.Progress", "BootProgress");
         const ProgressStages* progPtr = std::get_if<ProgressStages>(&retVal);
-        if (progPtr != nullptr)
+        if (progPtr == nullptr)
         {
             return false;
         }


### PR DESCRIPTION
Dump offload fails when bmc is rebooted as the host state check method is returning false even when host is in running state.

During normal IPL application will use propertyChanged signal to determine if host is in running state which works as expected.