### PR TITLE
Move to libpldm APIs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,4 +9,9 @@ project(
   ])  
 
 cpp = meson.get_compiler('cpp')
+
+if cpp.has_header('poll.h')
+  add_project_arguments('-DPLDM_HAS_POLL=1', language: 'cpp')
+endif
+
 subdir('dump')


### PR DESCRIPTION
- libpldm provides APIs for allocating instance IDs directly, which eliminates the need for remote dbus calls to the pldm daemon. Refactor the code to use these APIs and eliminate all the dbus operations.

- Replace pldm transport APIs with libpldm pldm_transport APIs to remove the dependency on pldm.

This change removes the dependency on pldm by utilizing the standardized libpldm APIs for transport operations, improving maintainability and compatibility.

We don't currently have the infrastructure in place to get the correct TIDs, so to keep everything working as before use the EID as the TID in the EID-to-TID mapping.

Change-Id: I348d54d9b5db47ef706cf7935e01ab8e7a55a594