### PR TITLE
start host offload handler as hmc managed

### DIFF
--- a/dump/hmc_state_watch.cpp
+++ b/dump/hmc_state_watch.cpp
@@ -52,16 +52,15 @@ void HMCStateWatch::propertyChanged(sdbusplus::message::message& msg)
                 const std::string& strValue = std::get<std::string>(attrValue);
                 if (strValue == "Enabled")
                 {
-                    _dumpQueue.hmcStateChange(true);
-                }
-                else
-                {
-                    _dumpQueue.hmcStateChange(false);
+                    // if it is hmc managed exit the service
+                    log<level::INFO>("HMC managed system exit the application");
+                    std::exit(0);
                 }
             }
             else
             {
                 log<level::ERR>("Unexpected value type for 'pvm_hmc_managed'");
+                std::exit(0);
             }
         }
     }

--- a/dump/host_offload_main.cpp
+++ b/dump/host_offload_main.cpp
@@ -24,10 +24,19 @@ int main()
         // runtime.
         // Not creating offloader objects if system is HMC managed
         // TODO #https://github.com/ibm-openbmc/powervm-handler/issues/8
-        if (openpower::dump::isSystemHMCManaged(bus))
+        try
         {
-            log<level::ERR>("HMC managed system exiting the application");
-            return 0;
+            if (openpower::dump::isSystemHMCManaged(bus))
+            {
+                log<level::ERR>("HMC managed system exiting the application");
+                return 0;
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            // BIOSconfig manager takes time to set the property so wait for
+            // property change callback method
+            log<level::INFO>("Failed to read 'pvm_hmc_managed' property");
         }
         openpower::dump::OffloadManager manager(bus, event);
         manager.offload();

--- a/dump/host_offloader_queue.cpp
+++ b/dump/host_offloader_queue.cpp
@@ -27,7 +27,16 @@ HostOffloaderQueue::HostOffloaderQueue(sdbusplus::bus::bus& bus,
 {
     // initally read the value as this app might run after host is started
     isHostRunning = openpower::dump::isHostRunning(_bus);
-    isHMCManagedSystem = openpower::dump::isSystemHMCManaged(_bus);
+    try
+    {
+        isHMCManagedSystem = openpower::dump::isSystemHMCManaged(_bus);
+    }
+    catch (const std::exception& ex)
+    {
+        // if failed to read at startup wait for hmc state change message
+        log<level::INFO>(
+            "Failed to read hmc managed property from BIOSConfig manager");
+    }
 
     // intially stop the timer, start only when dumps are added to the queue
     stopTimer();

--- a/dump/host_offloader_queue.hpp
+++ b/dump/host_offloader_queue.hpp
@@ -104,7 +104,7 @@ class HostOffloaderQueue
     bool isHostRunning = false;
 
     /** @brief Flag to indicate whether the system is HMC managed */
-    bool isHMCManagedSystem = false;
+    bool isHMCManagedSystem = true; // start as hmc managed system
     /**
      * @brief Attempt dump offload at every 5 seconds
      */


### PR DESCRIPTION
1) BIOConfig manager takes time to set the 'pvm_hmc_managed' property

2)If failed to read 'pvm_hmc_managed' property during startup treat system as HMC managed

3) When property change request is received exit the application if it is HMC managed else change it to non HMC managed system.

4) HMC to non HMC is disruptive but non HMC to hmc managed system is not disruptive.


Change-Id: I2a89210bba7ae81154544a308e8324b733d7b1b5