### PR TITLE
Move to libpldm instance id APIs

### DIFF
--- a/dump/dbus_util.cpp
+++ b/dump/dbus_util.cpp
@@ -24,10 +24,9 @@ bool isDumpProgressCompleted(sdbusplus::bus::bus& bus,
     }
     catch (const std::exception& ex)
     {
-        log<level::ERR>(
-            fmt::format("Util failed to get dump ({}) progress property ({})",
-                        objectPath, ex.what())
-                .c_str());
+        lg2::error(
+            "Util failed to dump progress property path:{PATH} exception:{EX}",
+            "PATH", objectPath, "EX", ex);
         throw;
     }
     return false;
@@ -62,20 +61,18 @@ uint64_t getDumpSize(sdbusplus::bus::bus& bus, const std::string& objectPath)
         const uint64_t* sizePtr = std::get_if<uint64_t>(&retVal);
         if (sizePtr == nullptr)
         {
-            std::string err = fmt::format(
-                "Util size value not set for dump object ({})", objectPath);
-            log<level::ERR>(err.c_str());
-            throw std::runtime_error(err);
+            lg2::error(
+                "Size property value not set for dump object path:{PATH} ",
+                "PATH", objectPath);
+            throw std::runtime_error("Size property value not set for dump");
         }
         size = *sizePtr;
     }
     catch (const std::exception& ex)
     {
-        log<level::INFO>(
-            fmt::format(
-                "Util failed to get dump size property object ({}) ex({})",
-                objectPath, ex.what())
-                .c_str());
+        lg2::info("Failed to get dump size property value "
+                  "exception:{EX} path:{PATH}",
+                  "EX", ex, "PATH", objectPath);
         throw;
     }
     return size;
@@ -98,9 +95,7 @@ bool isSystemHMCManaged(sdbusplus::bus::bus& bus)
             if (std::holds_alternative<std::string>(attrValue))
             {
                 const std::string& strValue = std::get<std::string>(attrValue);
-                log<level::INFO>(
-                    fmt::format("isSystemHMCManaged value ({})", strValue)
-                        .c_str());
+                lg2::info("isSystemHMCManaged : {VALUE} ", "VALUE", strValue);
                 return strValue == "Enabled";
             }
         }
@@ -127,18 +122,16 @@ bool isHostRunning(sdbusplus::bus::bus& bus)
         }
         if (*progPtr == ProgressStages::OSRunning)
         {
-            log<level::INFO>("Util host is in  BootProgress::OSRunning");
+            lg2::info("Host is in  BootProgress::OSRunning");
             return true;
         }
     }
     catch (const std::exception& ex)
     {
-        log<level::ERR>(
-            fmt::format("Util failed to read BootProgress property ({})",
-                        ex.what())
-                .c_str());
+        lg2::error("Failed to read BootProgress property exception:{EX}", "EX",
+                   ex);
     }
-    log<level::INFO>("Util host is not in  BootProgress::OSRunning state");
+    lg2::info("Host is not in BootProgress::OSRunning state");
     return false;
 }
 
@@ -169,18 +162,13 @@ const std::vector<std::string>
         mapperCall.append(intf);
         auto response = bus.call(mapperCall);
         response.read(liObjectPaths);
-        log<level::INFO>(
-            fmt::format("Util dumps size received is ({}) entry({})",
-                        liObjectPaths.size(), entryIntf)
-                .c_str());
+        lg2::info("Dumps size received is:{SIZE} entryIntf:{INTF}", "SIZE",
+                  liObjectPaths.size(), "INTF", entryIntf);
     }
     catch (const std::exception& ex)
     {
-        log<level::ERR>(
-            fmt::format(
-                "Util failed to get dump entry objects entry({}) ex({})",
-                entryIntf, ex.what())
-                .c_str());
+        lg2::error("Failed to get dump entry intf:{INTF} ex:{EX}", "INTF",
+                   entryIntf, "EX", ex);
         throw;
     }
     return liObjectPaths;

--- a/dump/dbus_util.hpp
+++ b/dump/dbus_util.hpp
@@ -2,17 +2,13 @@
 
 #include "utility.hpp"
 
-#include <fmt/format.h>
-
-#include <phosphor-logging/log.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <cstdint>
 
 namespace openpower::dump
 {
 using ::openpower::dump::utility::DBusPropertiesMap;
-using ::phosphor::logging::level;
-using ::phosphor::logging::log;
 using ::sdbusplus::message::object_path;
 
 using BaseBIOSTableItem = std::tuple<
@@ -83,11 +79,9 @@ T readDBusProperty(sdbusplus::bus::bus& bus, const std::string& service,
     }
     catch (const std::exception& ex)
     {
-        log<level::ERR>(
-            fmt::format("Failed to get the property ({}) interface ({}) "
-                        "object path ({}) error ({}) ",
-                        prop.c_str(), intf.c_str(), object.c_str(), ex.what())
-                .c_str());
+        lg2::error(
+            "Failed to get the property:{PROP} interface:{INTF} path:{PATH} ex:{EX}",
+            "PROP", prop, "INTF", intf, "PATH", object, "EX", ex);
         throw;
     }
     return retVal;

--- a/dump/dump_watch.cpp
+++ b/dump/dump_watch.cpp
@@ -41,7 +41,6 @@ void DumpWatch::interfaceAdded(sdbusplus::message::message& msg)
         sdbusplus::message::object_path objPath;
         DBusInteracesMap interfaces;
         msg.read(objPath, interfaces);
-        DBusInteracesMap::iterator iter = interfaces.begin();
         if (interfaces.find("com.ibm.Dump.Entry.Hostboot") ==
                 interfaces.end() &&
             interfaces.find("com.ibm.Dump.Entry.Hardware") ==

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -28,10 +28,15 @@ libpldm_dep = dependency(
     default_options: ['oem-ibm=enabled'],
 )
 
+conf_data = configuration_data()
+if cpp.has_header('poll.h')
+  add_project_arguments('-DPLDM_HAS_POLL=1', language: 'cpp')
+endif
+
 configure_file(
     input: 'config.h.in',
     output: 'config.h',
-    configuration: configuration_data(),
+    configuration: conf_data,
 )
 
 dump_offload_deps = [

--- a/dump/meson.build
+++ b/dump/meson.build
@@ -22,7 +22,11 @@ phosphor_logging_dep = dependency(
 )
 
 systemd_dep = dependency('systemd')
-pldm_dep = dependency('libpldm')
+
+libpldm_dep = dependency(
+    'libpldm',
+    default_options: ['oem-ibm=enabled'],
+)
 
 configure_file(
     input: 'config.h.in',
@@ -35,7 +39,7 @@ dump_offload_deps = [
     phosphor_logging_dep,
     sdbusplus_dep,
     sdeventplus_dep,
-    pldm_dep,
+    libpldm_dep,
 ]
 
 subdir('dist')

--- a/dump/pldm_oem_cmds.cpp
+++ b/dump/pldm_oem_cmds.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/lg2.hpp>
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
 
@@ -21,6 +22,7 @@ using namespace phosphor::logging;
 constexpr auto eidPath = "/usr/share/pldm/host_eid";
 constexpr mctp_eid_t defaultEIDValue = 9;
 
+PLDMInstanceManager instanceManager;
 using NotAllowed = sdbusplus::xyz::openbmc_project::Common::Error::NotAllowed;
 using Reason = xyz::openbmc_project::Common::NotAllowed::REASON;
 
@@ -79,6 +81,7 @@ void newFileAvailable(uint32_t dumpId, pldm_fileio_file_type pldmDumpType,
         reinterpret_cast<pldm_msg*>(newFileAvailReqMsg.data()));
     if (retCode != PLDM_SUCCESS)
     {
+        freePLDMInstanceID(pldmInstanceId, mctpEndPointId);
         log<level::ERR>(
             fmt::format(
                 "Failed to encode pldm New file req for new dump available "
@@ -89,12 +92,24 @@ void newFileAvailable(uint32_t dumpId, pldm_fileio_file_type pldmDumpType,
             "Acknowledging new file request failed due to encoding error"));
     }
 
-    internal::CustomFd pldmFd(openPLDM());
+    internal::CustomFd pldmFd = openPLDM();
+    if (pldmFd() < 0)
+    {
+        freePLDMInstanceID(pldmInstanceId, mctpEndPointId);
+        log<level::ERR>(
+            fmt::format("Failed to openPLDM for new dump available "
+                        "dumpId({}), pldmDumpType({}),rc({})",
+                        dumpId, static_cast<uint16_t>(pldmDumpType), retCode)
+                .c_str());
+        elog<NotAllowed>(
+            Reason("Failed to open PLDM for new dump available request"));
+    }
 
     retCode = pldm_send(mctpEndPointId, pldmFd(), newFileAvailReqMsg.data(),
                         newFileAvailReqMsg.size());
     if (retCode != PLDM_REQUESTER_SUCCESS)
     {
+        freePLDMInstanceID(pldmInstanceId, mctpEndPointId);
         auto errorNumber = errno;
         log<level::ERR>(
             fmt::format(
@@ -107,5 +122,8 @@ void newFileAvailable(uint32_t dumpId, pldm_fileio_file_type pldmDumpType,
         elog<NotAllowed>(Reason("New file available  via pldm is not "
                                 "allowed due to new file request send failed"));
     }
+    freePLDMInstanceID(pldmInstanceId, mctpEndPointId);
+    lg2::info("Done. PLDM message, id: {ID}, RC: {RC}", "ID", pldmInstanceId,
+              "RC", retCode);
 }
 } // namespace openpower::dump::pldm

--- a/dump/pldm_utils.hpp
+++ b/dump/pldm_utils.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <libpldm/instance-id.h>
 #include <libpldm/pldm.h>
 #include <unistd.h>
 
@@ -45,6 +46,31 @@ struct CustomFd
     }
 };
 } // namespace internal
+class PLDMInstanceManager
+{
+  public:
+    PLDMInstanceManager(const PLDMInstanceManager&) = delete;
+    PLDMInstanceManager& operator=(const PLDMInstanceManager&) = delete;
+
+    PLDMInstanceManager();
+    ~PLDMInstanceManager();
+
+  private:
+    /**
+     * @brief Instantiates an instance ID database object
+     *
+     * @return void
+     **/
+    void initPLDMInstanceIdDb();
+
+    /**
+     * @brief Destroys an instance ID database object
+     *
+     * @return void
+     **/
+    void destroyPLDMInstanceIdDb();
+};
+
 /**
  * @brief Opens the PLDM file descriptor
  *
@@ -57,10 +83,20 @@ int openPLDM();
 /**
  * @brief Returns the PLDM instance ID to use for PLDM commands
  *
- * @param[in] eid - The PLDM EID
+ * @param[in] tid - the terminus ID the instance ID is associated with
  *
- * @return uint8_t - The instance ID
+ * @return pldm_instance_id_t - The instance ID
  **/
-uint8_t getPLDMInstanceID(uint8_t eid);
+pldm_instance_id_t getPLDMInstanceID(uint8_t tid);
+
+/**
+ * @brief Free the PLDM instance ID
+ *
+ * @param[in] tid - the terminus ID the instance ID is associated with
+ * @param[in] instanceID - The PLDM instance ID
+ *
+ * @return void
+ **/
+void freePLDMInstanceID(pldm_instance_id_t instanceID, uint8_t tid);
 
 } // namespace openpower::dump::pldm

--- a/dump/pldm_utils.hpp
+++ b/dump/pldm_utils.hpp
@@ -3,49 +3,12 @@
 #pragma once
 #include <libpldm/instance-id.h>
 #include <libpldm/pldm.h>
+#include <libpldm/transport.h>
 #include <unistd.h>
 
 namespace openpower::dump::pldm
 {
-namespace internal
-{
-/** @struct CustomFd
- *
- *  RAII wrapper for file descriptor.
- */
-struct CustomFd
-{
-  private:
-    /** @brief File descriptor */
-    int fd = -1;
-
-  public:
-    CustomFd() = delete;
-    CustomFd(const CustomFd&) = delete;
-    CustomFd& operator=(const CustomFd&) = delete;
-    CustomFd(CustomFd&&) = delete;
-    CustomFd& operator=(CustomFd&&) = delete;
-
-    /** @brief Saves File descriptor and uses it to do file operation
-     *
-     *  @param[in] fd - File descriptor
-     */
-    CustomFd(int fd) : fd(fd) {}
-
-    ~CustomFd()
-    {
-        if (fd >= 0)
-        {
-            close(fd);
-        }
-    }
-
-    int operator()() const
-    {
-        return fd;
-    }
-};
-} // namespace internal
+extern struct pldm_transport* pldmTransport;
 class PLDMInstanceManager
 {
   public:
@@ -72,13 +35,23 @@ class PLDMInstanceManager
 };
 
 /**
- * @brief Opens the PLDM file descriptor
+ * @brief setup PLDM transport for sending and receiving messages
  *
+ * @param[in] eid - MCTP endpoint ID
  * @return file descriptor on success and throw
  *         exception (xyz::openbmc_project::Common::Error::NotAllowed) on
  *         failures.
  */
-int openPLDM();
+int openPLDM(mctp_eid_t eid);
+
+/** @brief Opens the MCTP socket for sending and receiving messages.
+ *
+ * @param[in] eid - MCTP endpoint ID
+ */
+int openMctpDemuxTransport(mctp_eid_t eid);
+
+/** @brief Close the PLDM file */
+void pldmClose();
 
 /**
  * @brief Returns the PLDM instance ID to use for PLDM commands

--- a/dump/subprojects/libpldm.wrap
+++ b/dump/subprojects/libpldm.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+url = https://github.com/openbmc/libpldm.git
+revision = HEAD
+
+[provide]
+libpldm = libpldm_dep


### PR DESCRIPTION
libpldm provides APIs for allocating instance IDs directly, which eliminates the need for remote dbus calls to the pldm daemon.  Refactor the code to use these APIs and eliminate all the dbus operations.

https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/72594
https://gerrit.openbmc.org/c/openbmc/phosphor-debug-collector/+/72595

Change-Id: I9b080baecf987aaebbc4dc2dc9d60e16885ac11d