### PR TITLE
Set PLDM dump type for MSBE dumps to SBE

### DIFF
--- a/dump/send_pldm_cmd.cpp
+++ b/dump/send_pldm_cmd.cpp
@@ -25,7 +25,8 @@ void sendNewDumpCmd(uint32_t dumpId, DumpType dumpType, uint64_t dumpSize)
             pldmDumpType = 0xF; // PLDM_FILE_TYPE_BMC_DUMP
             break;
         case DumpType::system:
-            if (dumpIdString.c_str()[0] == '3')
+            if (dumpIdString.c_str()[0] == '3' ||
+                dumpIdString.c_str()[0] == '4')
                 pldmDumpType = 0x10; // PLDM_FILE_TYPE_SBE_DUMP
             else if (dumpIdString.c_str()[0] == '2')
                 pldmDumpType = 0x11; // PLDM_FILE_TYPE_HOSTBOOT_DUMP


### PR DESCRIPTION
Fixed an issue where the MSBE dump offload was failing due to a missing
 PLDM dump type assignment. Since MSBE dumps are handled similarly to
SBE dumps, assign the PLDM dump type for MSBE to match that of SBE to ensure proper handling.

Test Results:

MSBE offload:

```
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Watch propertiesChanged object path (/xyz/openbmc_project/dump/system/entry/40000041)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Queue enqueue dump (/xyz/openbmc_project/dump/system/entry/40000041) size of Q (0)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Queue start timer host running (true) hmcmanaged (false)Dumps size  (1)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Queue offload initiating offload (/xyz/openbmc_project/dump/system/entry/40000041) id (1073741889) type (1) size (228
733)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: sendNewDumpCmd Id(1073741889) Size(228733) Type(1) PldmDumpType(16)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: encode_new_file_req Instance ID (1) DumpID (1073741889) DumpType (16) DumpSize(228733)  ReqMsgSize(17)
Apr 14 08:15:48 p10bmc pvm_dump_offload[9803]: Done. PLDM message, id: 1, RC: 0
Apr 14 08:16:05 p10bmc pldmd[9829]: FileHandle in findDumpObjPath is 1073741889
Apr 14 08:16:05 p10bmc pldmd[9829]: SBE dump entry path is /xyz/openbmc_project/dump/system/entry/40000041
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Watch interfaceRemoved path (/xyz/openbmc_project/dump/system/entry/40000041)
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Queue dequeue (/xyz/openbmc_project/dump/system/entry/40000041) size of Q (1)
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Queue offloaded dump completed (/xyz/openbmc_project/dump/system/entry/40000041)
Apr 14 08:16:24 p10bmc pvm_dump_offload[9803]: Queue stop timer host running (true) hmcmanaged (false)Dumps size  (0)
```

SBE offload:

```
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Watch propertiesChanged object path (/xyz/openbmc_project/dump/system/entry/30000040)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Queue enqueue dump (/xyz/openbmc_project/dump/system/entry/30000040) size of Q (0)
Apr 14 08:13:09 p10bmc pldmd[9829]: sdeventplus: ioCallback: Instance ID 0 for TID 9 was not previously allocated
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Queue start timer host running (true) hmcmanaged (false)Dumps size  (1)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Queue offload initiating offload (/xyz/openbmc_project/dump/system/entry/30000040) id (805306432) type (1) size (258641)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: sendNewDumpCmd Id(805306432) Size(258641) Type(1) PldmDumpType(16)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Got instanceId: 0 from PLDM eid: 9
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: encode_new_file_req Instance ID (0) DumpID (805306432) DumpType (16) DumpSize(258641)  ReqMsgSize(17)
Apr 14 08:13:09 p10bmc pvm_dump_offload[9803]: Done. PLDM message, id: 0, RC: 0
Apr 14 08:13:39 p10bmc pldmd[9829]: FileHandle in findDumpObjPath is 805306432
Apr 14 08:13:39 p10bmc pldmd[9829]: SBE dump entry path is /xyz/openbmc_project/dump/system/entry/30000040
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Watch interfaceRemoved path (/xyz/openbmc_project/dump/system/entry/30000040)
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Queue dequeue (/xyz/openbmc_project/dump/system/entry/30000040) size of Q (1)
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Queue offloaded dump completed (/xyz/openbmc_project/dump/system/entry/30000040)
Apr 14 08:13:39 p10bmc pvm_dump_offload[9803]: Queue stop timer host running (true) hmcmanaged (false)Dumps size  (0)
```

Change-Id: I284e4d738a5172423b95d1b8871a1a5833239be3